### PR TITLE
Enable counties from external source

### DIFF
--- a/src/addfips/addfips.py
+++ b/src/addfips/addfips.py
@@ -30,6 +30,7 @@ COUNTY_PATTERN = r" (county|city|city and borough|borough|census area|municipio|
 DIACRETICS = {
     r"ñ": "n",
     r"'": "",
+    r".": "",
     r"ó": "o",
     r"í": "i",
     r"á": "a",
@@ -41,10 +42,11 @@ DIACRETICS = {
     r"ì": "i",
     r"å": "a",
 }
+
 ABBREVS = {
-    'ft. ': 'fort ',
-    'st. ': 'saint ',
-    'ste. ': 'sainte ',
+    'ft ': 'fort ',
+    'st ': 'saint ',
+    'ste ': 'sainte ',
 }
 
 
@@ -58,7 +60,7 @@ class AddFIPS:
 
     def __init__(self, vintage=None):
         # Handle de-diacreticizing
-        self.diacretic_pattern = '(' + ('|'.join(DIACRETICS)) + ')'
+        self.diacretic_pattern = '|'.join(re.escape(key) for key in DIACRETICS)
         self.delete_diacretics = lambda x: DIACRETICS[x.group()]
 
         if vintage is None or vintage not in COUNTY_FILES:


### PR DESCRIPTION
This PR adds two features to this utility. 

1. By specifying `external_county_data` on initialization, a user can supply their own county records provided it's an array of dictionaries and each row contains `statefp`, `countyfp`, and `name` attributes.
2. It enables matching of county names with a `.` by normalizing the county name. Prior to this change `St. Joseph` would result in a match but `St Joseph` would not. 